### PR TITLE
Enable compatibility with Rust 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 
 rust:
+  - 1.12.0
   - stable
   - beta
   - nightly

--- a/src/epoch/atomic.rs
+++ b/src/epoch/atomic.rs
@@ -10,13 +10,12 @@ use epoch::Scope;
 /// appropriate ordering for the failure case.
 #[inline]
 fn strongest_failure_ordering(ord: Ordering) -> Ordering {
-    use self::Ordering::*;
+    use std::sync::atomic::Ordering::*;
     match ord {
         Relaxed => Relaxed,
         Release => Relaxed,
         Acquire => Acquire,
         AcqRel => Acquire,
-        SeqCst => SeqCst,
         _ => SeqCst,
     }
 }


### PR DESCRIPTION
Rayon currently supports Rust 1.12 or later, but we can't update to the
latest coco because of a small difference in item visibility to `use`.
It's a simple change to make this work though.

There's also a difference that the old `Ordering` didn't have the hidden
`__Nonexhaustive` variant, but we can deal with this by just matching
`SeqCst` in the catch-all pattern too.